### PR TITLE
Replace up/down arrow symbol

### DIFF
--- a/README.org
+++ b/README.org
@@ -40,7 +40,7 @@ If you use ~use-package~, here is the recipe for installing it.
 Casual requires Emacs 29.1+.
 
 * Usage
-A number of Avy commands have the option to limit the scope of candidates to the visible part of the current buffer above or below the point. Such commands are denoted with the ‘↕︎’ symbol. Press ~a~ to limit the scope above the point, ~b~ for below.
+A number of Avy commands have the option to limit the scope of candidates to the visible part of the current buffer above or below the point. Such commands are denoted with the ‘⬍’ symbol. Press ~a~ to limit the scope above the point, ~b~ for below.
 
 The commands listed under *Edit Other Line/Region* can perform an operation on a visible line or region while keeping the point stationary. This enables a workflow where a different visible part of the Emacs frame can be operated on without having to move the point.
 

--- a/lisp/casual-avy.el
+++ b/lisp/casual-avy.el
@@ -188,21 +188,21 @@ Always choose love."
 ;;;###autoload (autoload 'casual-avy-tmenu "casual-avy" nil t)
 (transient-define-prefix casual-avy-tmenu ()
   "Casual Avy Transient menu."
-  ["Option (applies to ↕︎)"
+  ["Option (applies to ⬍)"
    :class transient-row
    ("a" "Above" "--above")
    ("b" "Below" "--below")]
   [["Goto Thing"
     ("c" "Character" avy-goto-char-timer :transient nil)
-    ("2" "2 Characters ↕︎" ca-avy-goto-char-2 :transient nil)
-    ("w" "Word ↕︎" ca-avy-goto-word-1 :transient nil)
-    ("s" "Symbol ↕︎" ca-avy-goto-symbol-1 :transient nil)
-    ("W" "Whitespace end ↕︎" ca-avy-goto-whitespace-end :transient nil)
+    ("2" "2 Characters ⬍" ca-avy-goto-char-2 :transient nil)
+    ("w" "Word ⬍" ca-avy-goto-word-1 :transient nil)
+    ("s" "Symbol ⬍" ca-avy-goto-symbol-1 :transient nil)
+    ("W" "Whitespace end ⬍" ca-avy-goto-whitespace-end :transient nil)
     ("p" "Pop mark" avy-pop-mark :transient nil)]
 
    ["Goto Line"
     :pad-keys t
-    ("l" "Line ↕︎" ca-avy-goto-line :transient nil)
+    ("l" "Line ⬍" ca-avy-goto-line :transient nil)
     ("e" "End of line" avy-goto-end-of-line :transient nil)
     ("o" "Org heading" avy-org-goto-heading-timer
      :if ca-org-mode-p


### PR DESCRIPTION
- Prior Unicode symbol had irregular spacing for Linux typefaces.
  Replacing with symbol that is hopefully more consistent across typefaces.
