### PR TITLE
Add Imenu configuration to README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -66,11 +66,12 @@ By enabling “Use Unicode Symbols” from the Settings menu, Casual Avy will us
 | Next     | Next     | ↓       |
 
 ** Imenu (index) Support
-The Emacs [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Imenu.html][Imenu]] (index menu) feature offers a way to navigate to a major definition in a file, provided that the current mode supports it. As Imenu behavior is closely related to Avy, support for it is provided here as the menu item labeled "(i) Index". Be sure to enable the index menu to get the benefits:
+The Emacs [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Imenu.html][Imenu]] (index menu) feature offers a way to navigate to a major definition in a file, provided that the current mode supports it. As Imenu behavior is closely related to Avy, support for it is provided here as the menu item labeled "(i) Index". The following configuration code turns on index menus for Markdown, Org, Makefile, and programming language modes.
 #+begin_src elisp :lexical no
   (add-hook 'markdown-mode-hook #'imenu-add-menubar-index)
   (add-hook 'makefile-mode-hook #'imenu-add-menubar-index)
   (add-hook 'prog-mode-hook #'imenu-add-menubar-index)
+  (add-hook 'org-mode-hook #'imenu-add-menubar-index)
 #+end_src
 
 ** Org Support

--- a/README.org
+++ b/README.org
@@ -66,7 +66,12 @@ By enabling “Use Unicode Symbols” from the Settings menu, Casual Avy will us
 | Next     | Next     | ↓       |
 
 ** Imenu (index) Support
-The Emacs [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Imenu.html][Imenu]] (index menu) feature offers a way to navigate to a major definition in a file, provided that the current mode supports it. As Imenu behavior is closely related to Avy, support for it is provided here as the menu item labeled "(i) Index".
+The Emacs [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Imenu.html][Imenu]] (index menu) feature offers a way to navigate to a major definition in a file, provided that the current mode supports it. As Imenu behavior is closely related to Avy, support for it is provided here as the menu item labeled "(i) Index". Be sure to enable the index menu to get the benefits:
+#+begin_src elisp :lexical no
+  (add-hook 'markdown-mode-hook #'imenu-add-menubar-index)
+  (add-hook 'makefile-mode-hook #'imenu-add-menubar-index)
+  (add-hook 'prog-mode-hook #'imenu-add-menubar-index)
+#+end_src
 
 ** Org Support
 If the current buffer is an Org file, then two menu items are supported:


### PR DESCRIPTION
Added recommendation to enable the imenu index.

Without first enabling imenu (via something like `imenu-add-menubar-index`), it's not available through the transient menu. Added the recommendation to enable it using the suggestion from http://yummymelon.com/devnull/til-imenu.html.

After reading the TIL Imenu article, I found myself agreeing with the statements that "Here’s the funny thing though. Most other IDEs don’t even bother to name an index menu feature as it is enabled (or rather, baked-in) in the UI _by default_. So I think it should be with Emacs." And so was happy to see that support had been added to casual-avy. But it took me a bit of time to realize that casual-avy supported imenu but didn't turn on the index _by default_. Commenting on that in the README could be useful to people who are puzzled why they're not seeing the imenu option.