### PR TITLE
Merge development to main 20240713_190206

### DIFF
--- a/README.org
+++ b/README.org
@@ -66,7 +66,13 @@ By enabling “Use Unicode Symbols” from the Settings menu, Casual Avy will us
 | Next     | Next     | ↓       |
 
 ** Imenu (index) Support
-The Emacs [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Imenu.html][Imenu]] (index menu) feature offers a way to navigate to a major definition in a file, provided that the current mode supports it. As Imenu behavior is closely related to Avy, support for it is provided here as the menu item labeled "(i) Index".
+The Emacs [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Imenu.html][Imenu]] (index menu) feature offers a way to navigate to a major definition in a file, provided that the current mode supports it. As Imenu behavior is closely related to Avy, support for it is provided here as the menu item labeled "(i) Index". The following configuration code turns on index menus for Markdown, Org, Makefile, and programming language modes.
+#+begin_src elisp :lexical no
+  (add-hook 'markdown-mode-hook #'imenu-add-menubar-index)
+  (add-hook 'makefile-mode-hook #'imenu-add-menubar-index)
+  (add-hook 'prog-mode-hook #'imenu-add-menubar-index)
+  (add-hook 'org-mode-hook #'imenu-add-menubar-index)
+#+end_src
 
 ** Org Support
 If the current buffer is an Org file, then two menu items are supported:

--- a/lisp/casual-avy-version.el
+++ b/lisp/casual-avy-version.el
@@ -22,7 +22,7 @@
 
 ;;; Code:
 
-(defconst casual-avy-version "1.4.0"
+(defconst casual-avy-version "1.4.1"
   "Casual Avy Version.")
 
 (defun casual-avy-version ()

--- a/lisp/casual-avy.el
+++ b/lisp/casual-avy.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual-avy
 ;; Keywords: tools
-;; Version: 1.4.0
+;; Version: 1.4.1
 ;; Package-Requires: ((emacs "29.1") (avy "0.5.0") (casual-lib "1.1.0"))
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
- **Update README.org**
  Added recommendation to enable the imenu index.
  
  Without first enabling imenu (via something like imenu-add-menubar-index), it's not available through the transient menu. Added the recommendation to enable it using the suggestion from http://yummymelon.com/devnull/til-imenu.html.

- **Update README.org**
  Made requested changes to documentation.

- **Bump version to 1.4.1**
  